### PR TITLE
CI Pipeline

### DIFF
--- a/.github/setup-env.sh
+++ b/.github/setup-env.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+# Add environment setup commands here
+
+mkdir bin
+# this is a dirty node release, we should use the anvil one with they are available
+# Download eth-rpc binary
+curl -L https://github.com/paritytech/hardhat-polkadot/releases/download/nodes-19631614896/eth-rpc-linux-x64 -o bin/eth-rpc
+chmod +x bin/eth-rpc
+# Download revive-dev-node binary
+curl -L https://github.com/paritytech/hardhat-polkadot/releases/download/nodes-19631614896/revive-dev-node-linux-x64 -o bin/dev-node
+chmod +x bin/dev-node

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: Hardhat Tests
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Setup environment
+        run: ./.github/setup-env.sh
+
+      - name: Compile contracts
+        run: npx hardhat compile
+
+      - name: Run tests
+        run: npx hardhat test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Hardhat Tests
 
 on:
   push:
-    branches: [main, master]
+    branches: [main]
   pull_request:
-    branches: [main, master]
+    branches: [main]
 
 jobs:
   test:

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -30,11 +30,6 @@ const config: HardhatUserConfig = {
             polkadot: true,
             url: `http://127.0.0.1:8545`,
         },
-        polkadotHubTestnet: {
-            polkadot: true,
-            url: "https://testnet-passet-hub-eth-rpc.polkadot.io",
-            accounts: [vars.get("PRIVATE_KEY")],
-        },
     },
     preprocess: {
         eachLine: (hre) => ({

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "hardhat test",
+    "compile": "hardhat compile"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
## Add GitHub CI Pipeline

Closes #3

### Changes
- Add GitHub Actions workflow to run Hardhat tests on pull requests and main branch pushes
- Add setup script to fetch Polkadot node binaries (`eth-rpc` and `revive-dev-node`) from [hardhat-polkadot releases](https://github.com/paritytech/hardhat-polkadot/releases)
- Add npm scripts for `test` and `compile`
- Remove unused `polkadotHubTestnet` network config

### CI Workflow
- Triggers on: PRs to main/master, pushes to main/master
- Node.js 22 with npm caching
- Compiles contracts and runs full test suite